### PR TITLE
Add compress layout

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,3 +28,7 @@ navigation:
       link: /contact.html
     - title: '&amp;c.'
       link: /misc.html
+
+compress_html:
+    clippings: [html, head, title, base, link, meta, style, body, article, section, nav, aside, h1, h2, h3, h4, h5, h6, hgroup, header, footer, address, p, hr, blockquote, ol, ul, li, dl, dt, dd, figure, figcaption, main, div, table, caption, colgroup, col, tbody, thead, tfoot, tr, td, th]
+    endings: [html, head, body, li, dt, dd, p, rt, rp, optgroup, option, colgroup, caption, thead, tbody, tfoot, tr, td, th]

--- a/_layouts/compress.html
+++ b/_layouts/compress.html
@@ -1,0 +1,11 @@
+---
+#
+# Jekyll layout that compresses HTML
+# v0.3.1
+# https://github.com/penibelst/jekyll-compress-html
+# © 2014 Anatol Broder (http://penibelst.de/)
+# MIT License
+#
+---
+
+{% assign _pres = content | split: '<pre' %}{% for _pre1 in _pres %}{% assign _pre2 = _pre1 | split: '</pre>' %}{% if _pre2.size == 2 %}<pre{{ _pre2.first }}</pre>{% endif %}{% assign _second = _pre2.last | split: ' ' | join: ' ' %}{% for _element in site.compress_html.clippings %}{% assign _edges = ' <element,<element; </element>,</element>;</element> ,</element>' | replace: 'element', _element | split: ';' %}{% for _edge in _edges %}{% assign _replacement = _edge | split: ',' %}{% assign _second = _second | replace: _replacement[0], _replacement[1] %}{% endfor %}{% endfor %}{% for _element in site.compress_html.endings %}{% assign _closing = '</element>' | replace: 'element', _element %}{% assign _second = _second | remove: _closing %}{% endfor %}{{ _second }}{% endfor %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,3 +1,7 @@
+---
+layout: compress
+---
+
 <!DOCTYPE html>
 <html>
     <head>


### PR DESCRIPTION
As an answer to drawbacks of Liquid in your [article about Jekyll](http://homes.cs.washington.edu/~asampson/blog/jekyll.html):

> No whitespace control. This means that every {% if %} and {% for %} you use craps up your HTML output with ugly spaces and newlines.

I propose to compress whitespace with my [layout](https://github.com/penibelst/jekyll-compress-html). 
