### PR TITLE
fix link for CURC 🐄

### DIFF
--- a/_posts/2015-11-25-apply.md
+++ b/_posts/2015-11-25-apply.md
@@ -84,5 +84,5 @@ Oh, and [we're in New York City][tech] too.
 
 There are [cows][curc]! Right on campus! You can hang out with them, [just like Greg][gregcows]!
 
-[curc]: http://dairy.cornell.edu/extension-education/ruminant-center
+[curc]: https://ansci.cals.cornell.edu/about-us/facilities
 [gregcows]: https://www.quora.com/Why-is-Professor-Greg-Morrisett-so-fond-of-cows


### PR DESCRIPTION
The proposed link is the closest I could find to a dedicated webpage