### PR TITLE
Updated link to llvm-mirror

### DIFF
--- a/_posts/2015-08-03-llvm.md
+++ b/_posts/2015-08-03-llvm.md
@@ -98,7 +98,7 @@ You will need to get friendly with the documentation. I find these links in part
 [bholt]: http://bholt.org
 [buildllvm]: http://llvm.org/docs/CMake.html
 [buildclang]: http://clang.llvm.org/get_started.html
-[llvm-gh]: https://github.com/llvm-mirror/llvm
+[llvm-gh]: https://github.com/llvm/llvm-project
 [langref]: http://llvm.org/docs/LangRef.html
 [progman]: http://llvm.org/docs/ProgrammersManual.html
 [passtut]: http://llvm.org/docs/WritingAnLLVMPass.html


### PR DESCRIPTION
Old LLVM link is to an archived version, updated (and official) version is https://github.com/llvm/llvm-project. 