### PR TITLE
Fix typo in post `LLVM for Grad Students`

### DIFF
--- a/_posts/2015-08-03-llvm.md
+++ b/_posts/2015-08-03-llvm.md
@@ -287,7 +287,7 @@ for (auto& B : F) {
 
 Details:
 
-* That `dyn_cast<T>(p)` construct is an [LLVM-specific introspection utility][llvm rtti]. It uses some conventions from the LLVM codebase to made dynamic type tests efficient, because compilers have to use them all the time. This particular construct returns a null pointer if `I` is not a `BinaryOperator`, so it's perfect for special-casing like this.
+* That `dyn_cast<T>(p)` construct is an [LLVM-specific introspection utility][llvm rtti]. It uses some conventions from the LLVM codebase to make dynamic type tests efficient, because compilers have to use them all the time. This particular construct returns a null pointer if `I` is not a `BinaryOperator`, so it's perfect for special-casing like this.
 * The [IRBuilder][irbuilder] is for constructing code. It has a million methods for creating any kind of instruction you could possibly want.
 * To stitch our new instruction into the code, we have to find all the places it's used and swap in our new instruction as an argument. Recall that an Instruction is a Value: here, the multiply Instruction is used as an operand in another Instruction, meaning that the product will be fed in as an argument.
 * We should probably also remove the old instruction, but I left bit that off for brevity.


### PR DESCRIPTION
Fix typo **made** to **make** in sentence 
> It uses some conventions from the LLVM codebase to **made** dynamic type tests efficient

Also, thanks for this amazing guide. Helps a lot!