### PR TITLE
Update hyperlink to "pin-tool"

### DIFF
--- a/_posts/2015-08-03-llvm.md
+++ b/_posts/2015-08-03-llvm.md
@@ -41,7 +41,7 @@ A compiler infrastructure is useful whenever you need to *do stuff with programs
 * hacking the kernel to intercept system calls
 * anything resembling a hypervisor
 
-[pin]: http://www.pintool.org/
+[pin]: https://software.intel.com/content/www/us/en/develop/articles/pin-a-dynamic-binary-instrumentation-tool.html
 [wddd]: http://research.cs.wisc.edu/vertical/papers/2014/wddd-sim-harmful.pdf
 
 Even if a compiler doesn't seem like a *perfect* match for your task, it can often get you 90% of the way there far easier than, say, a source-to-source translation.


### PR DESCRIPTION
The `pintool.org` link no longer works (it redirects to the intel [homepage](https://www.intel.com/content/www/us/en/homepage.html)). I believe the link I have changed it to is the desired one (it's the first that came up in a google search).