### PR TITLE
typo: remove extra not

### DIFF
--- a/_posts/2024-07-26-bril.md
+++ b/_posts/2024-07-26-bril.md
@@ -175,7 +175,7 @@ While a *laissez faire* approach to extensions has worked so far, it's also a me
 there's no systematic way to tell which extensions a given program uses or which language features a given tool supports.
 [A more explicit approach to extensibility][38] would make the growing ecosystem easier to manage.
 
-Finally, Bril does not require not SSA.
+Finally, Bril does not require SSA.
 There is [an SSA form][ssa] that includes a `phi` instruction, but the language itself has mutable variables.
 I wouldn't recommend this strategy for any other IL, but it's helpful for teaching for three big reasons:
 


### PR DESCRIPTION
The extra not seems wrong to me. I'm not a native speaker so I might be wrong.